### PR TITLE
Tuning config file to use keyboard teleop twist

### DIFF
--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -34,7 +34,7 @@
           stamped:      true
         keyboard_control:
           topic:        "walking_twist/keyboard"
-          timeout:      0.5
+          timeout:      0.75
           priority:     10
           short_desc:   "Manual control via keyboard"
           stamped:      true

--- a/config/mux_twists.yaml
+++ b/config/mux_twists.yaml
@@ -26,15 +26,16 @@
         #   timeout:     0.5
         #   priority:    1
         #   short_desc:  "Navigation stack controller"
-        # navigation_stack_controller:
-        #   topic:       "input/joystick"
-        #   timeout:     0.1
-        #   priority:    10
-        #   short_desc:  "Navigation stack remote control"
         remote_control:
           topic:        "walking_twist/manual"
           timeout:      0.5
           priority:     9
-          short_desc:   "Manual control"
+          short_desc:   "Manual control via game pad"
+          stamped:      true
+        keyboard_control:
+          topic:        "walking_twist/keyboard"
+          timeout:      0.5
+          priority:     10
+          short_desc:   "Manual control via keyboard"
           stamped:      true
 


### PR DESCRIPTION
A new keyboard manual control node is being added to the system. This node can output commanded velocity signals. These signals need to be piped into the mux to be passed out to the rest of the system. Note that this keyboard node is getting the highest priority currently. 

See system-level related PR for reference:
https://github.com/9Volts2Ground/wanda_ros2/pull/82